### PR TITLE
feat: BD-334 remove localisation from general templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/default-bug.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default-bug.md
@@ -22,7 +22,6 @@ JIRA issue: <!--JIRA_issue_ID-->
 - [ ] New and updated code does not triggers linter warnings or errors
 - [ ] Changes are made according to style guide and coding standards of this project
 - [ ] Required documentation is added and/or updated (Inline and/or README)
-- [ ] User facing strings(/texts) are localized
 - [ ] New extension/helper/code is not duplicated
 - [ ] Required Logging is added
 - [ ] The code has been thoroughly reviewed for potential security vulnerabilities

--- a/.github/PULL_REQUEST_TEMPLATE/default-feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default-feature.md
@@ -21,7 +21,6 @@ JIRA issue: <!--JIRA_issue_ID-->
 - [ ] New and updated code does not triggers linter warnings or errors
 - [ ] Changes are made according to style guide and coding standards of this project
 - [ ] Required documentation is added and/or updated (Inline and/or README)
-- [ ] User facing strings(/texts) are localized
 - [ ] New extension/helper/code is not duplicated
 - [ ] Required Logging is added
 - [ ] The code has been thoroughly reviewed for potential security vulnerabilities

--- a/.github/PULL_REQUEST_TEMPLATE/default-other.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default-other.md
@@ -20,7 +20,6 @@ JIRA issue: <!--JIRA_issue_ID-->
 - [ ] New and updated code does not triggers linter warnings or errors
 - [ ] Changes are made according to style guide and coding standards of this project
 - [ ] Required documentation is added and/or updated (Inline and/or README)
-- [ ] User facing strings(/texts) are localized
 - [ ] New extension/helper/code is not duplicated
 - [ ] Required Logging is added
 - [ ] The code has been thoroughly reviewed for potential security vulnerabilities


### PR DESCRIPTION
# Description
JIRA issue: BD-334
<!--github automatically converts JIRA IDs into clickable links-->
<!--Add reference documentations and description of changes in this PR that gives additional context to reviewers-->
Since there is no common organisation policy for handling localisation across project this checklist item is being removed for the time being. It is supposed to be brought back when aforementioned policy is created.

### Visual reference
<!--Add screenshots, video recording or other visual reference for changes if applicable-->
N/A
# How to Test
<!--Add testing steps needed to verify changes-->
N/A
# Inter project dependencies
<!--specify any inter project dependencies related to this PR-->
N/A
# Additional considerations
<!--is it breaking change; requires upstream/downstream update; what is recovery/fallback-->
N/A
# Checklist
- [x] New and updated code is logically covered with tests and does not violate product requirements
- [x] New and updated code does not triggers linter warnings or errors
- [x] Changes are made according to style guide and coding standards of this project
- [x] Required documentation is added and/or updated (Inline and/or README)
- [x] User facing strings(/texts) are localized
- [x] New extension/helper/code is not duplicated
- [x] Required Logging is added
- [x] The code has been thoroughly reviewed for potential security vulnerabilities
- [x] Sensitive information is not exposed in code or configuration
- [x] Exception handled properly